### PR TITLE
Dremel and DisplayLayerProgress plugin fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # OctoPrint-FlashForge Changelog
 
+## 0.1.16 (2020-5-8)
+* Support .3drem files for Dremel printers
+* Fix for hanging when DisplayLayerProgress plugin is in use (Thanks @jumpingmushroom)
+
 ## 0.1.15 (2020-5-4)
 * Fixes for issues uploading to SD card on newer printers such as Finder v2 (Thanks @boozecouncil)
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # OctoPrint-FlashForge
 
-Add support to the [Octoprint](https://octoprint.org) 3D printer web interface for communication with closed source printers such as the:
+Adds support to the [Octoprint](https://octoprint.org) 3D printer web interface for communication with closed source printers such as the:
 - FlashForge Finder, FlashForge Dreamer, FlashForge Dreamer NX, FlashForge Inventor, FlashForge Creator Max, FlashForge Ultra 2.0
 - PowerSpec Ultra 3DPrinter 2.0
 - Dremel Idea Builder 3D20

--- a/octoprint_flashforge/__init__.py
+++ b/octoprint_flashforge/__init__.py
@@ -34,6 +34,7 @@ class FlashForgePlugin(octoprint.plugin.SettingsPlugin,
 		self._currentFile = None
 		self._upload_percent = 0
 		self._vendor_id = 0
+		self._vendor_name = ""
 		self._device_id = 0
 		# FlashForge friendly default connection settings
 		self._conn_settings = {
@@ -118,6 +119,7 @@ class FlashForgePlugin(octoprint.plugin.SettingsPlugin,
 					if device_id in self.PRINTER_IDS[vendor_name]:
 						self._logger.info("Found a {} {}".format(vendor_name, self.PRINTER_IDS[vendor_name][device_id]))
 						self._vendor_id = vendor_id
+						self._vendor_name = vendor_name
 						self._device_id = device_id
 						break
 					else:
@@ -141,10 +143,15 @@ class FlashForgePlugin(octoprint.plugin.SettingsPlugin,
 
 	# Supported file extensions for SD upload
 	def get_extension_tree(self, *args, **kwargs):
+		if self._vendor_name == "Dremel":
+			return dict(
+				machinecode=dict(
+					g3drem=["g3drem"]	# Dremel file with image
+				)
+			)
 		return dict(
 			machinecode=dict(
-				gx=["gx"],			# FlashForge file with image
-				g3drem=["g3drem"]	# Dremel file with image
+				gx=["gx"]	# FlashForge file with image
 			)
 		)
 

--- a/octoprint_flashforge/__init__.py
+++ b/octoprint_flashforge/__init__.py
@@ -143,7 +143,8 @@ class FlashForgePlugin(octoprint.plugin.SettingsPlugin,
 	def get_extension_tree(self, *args, **kwargs):
 		return dict(
 			machinecode=dict(
-				gx=["gx"]
+				gx=["gx"],			# FlashForge file with image
+				g3drem=["g3drem"]	# Dremel file with image
 			)
 		)
 
@@ -156,6 +157,11 @@ class FlashForgePlugin(octoprint.plugin.SettingsPlugin,
 	def on_disconnect(self):
 		self._logger.debug("on_disconnect()")
 		self._serial_obj = None
+
+
+	def valid_command(self, command):
+		gcode = format(command.split(" ", 1)[0])
+		return (gcode[0] in ["G", "M"]) and gcode not in ["M117"]
 
 
 	# Called when gcode commands are being placed in the queue by OctoPrint:

--- a/octoprint_flashforge/flashforge.py
+++ b/octoprint_flashforge/flashforge.py
@@ -189,6 +189,9 @@ class FlashForge(object):
 
 		# strip carriage return, etc so we can terminate lines the FlashForge way
 		data = data.strip(' \r\n')
+		# try to filter out garbage commands (we need to replace with something harmless)
+		if len(data) and not self._plugin.valid_command(data):
+			data = "M119"
 
 		try:
 			self._logger.debug("FlashForge.write() {0}".format(data))

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ plugin_package = "octoprint_flashforge"
 plugin_name = "OctoPrint-FlashForge"
 
 # The plugin's version. Can be overwritten within OctoPrint's internal data via __plugin_version__ in the plugin module
-plugin_version = "0.1.15"
+plugin_version = "0.1.16"
 
 # The plugin's description. Can be overwritten within OctoPrint's internal data via __plugin_description__ in the plugin
 # module


### PR DESCRIPTION
Support .3drem files for Dremel printers
Fix for hanging when DisplayLayerProgress plugin is in use