### PR TITLE
Adding SD Card Upload support for Creator Pro 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ feedback.
 |Creator 3			|No (no USB port)		|No (no USB port)					|No (no USB port)				|
 |Creator Max		|?					    |?									|?								|
 |Creator Pro		|No	(Use GPX plugin)	|No	(Use GPX plugin)				|No	(Use GPX plugin)			|
-|Creator Pro 2		|No	(Use GPX plugin)	|Yes                				|Yes (IDEX in development)		|
+|Creator Pro 2		|Yes					|Yes                				|Yes (IDEX in development)		|
 |Dreamer			|Yes					|?									|?								|
 |Dreamer NX			|Yes					|?									|?								|
 |Finder v1			|Yes					|Yes								|Yes							|

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ feedback.
 |Creator 3			|No (no USB port)		|No (no USB port)					|No (no USB port)				|
 |Creator Max		|?					    |?									|?								|
 |Creator Pro		|No	(Use GPX plugin)	|No	(Use GPX plugin)				|No	(Use GPX plugin)			|
-|Creator Pro 2		|Yes					|Yes                				|Yes (IDEX in development)		|
+|Creator Pro 2		|Yes					|Yes                				|Yes (printing with 1 extruder, IDEX in development)		|
 |Dreamer			|Yes					|?									|?								|
 |Dreamer NX			|Yes					|?									|?								|
 |Finder v1			|Yes					|Yes								|Yes							|

--- a/octoprint_flashforge/__init__.py
+++ b/octoprint_flashforge/__init__.py
@@ -363,10 +363,15 @@ class FlashForgePlugin(octoprint.plugin.SettingsPlugin,
 
 		if not self._serial_obj:
 			return
+			
+		self._logger.debug("upload_to_sd")
+
 
 		def process_upload():
 			error = ""
 			errormsg = "Unable to upload to SD card"
+			
+			self._logger.debug("M28 Upload Handler")
 
 			# TODO: should be able to remove this if we can detect and notify if a print job is running when we connect
 			#  to the printer or if the job is started manually on the printer display because we should never get this far
@@ -383,18 +388,27 @@ class FlashForgePlugin(octoprint.plugin.SettingsPlugin,
 
 			# make sure heaters are off
 			ok, answer = self._serial_obj.sendcommand(b"M104 S0 T0")
+			
+			
+			self._logger.debug("M28 Upload Handler M104 send")
+			
 			if not ok:
 				error = "{}: {}".format(errormsg, answer)
 				errormsg += " - printer busy."
 			else:
 				self._serial_obj.sendcommand(b"M104 S0 T1")
 				self._serial_obj.sendcommand(b"M140 S0")
-
-				if self._printer_profile['name'] in SPECIAL_SD_HANDLING:
+				self._logger.debug(self._printer_profile['name'])
+				self._logger.debug(self.SPECIAL_SD_HANDLING)
+				if self._printer_profile['name'] in self.SPECIAL_SD_HANDLING:
+					self._logger.debug("M28 FFCP2 Handling")
 					ok, answer = self._serial_obj.sendcommand(b"M28 %d 1:%s" % (file_size, remote_name.encode()), 5000)
 				else:
+					self._logger.debug("M28 Standard Handling")
 					ok, answer = self._serial_obj.sendcommand(b"M28 %d 0:/user/%s" % (file_size, remote_name.encode()), 5000)
+                    
 				if not ok or b"open failed" in answer:
+					self._logger.debug("could not create file on printer sd card")
 					error = "{}: {}".format(errormsg, answer)
 					errormsg += " - could not create file on printer SD card."
 
@@ -444,7 +458,7 @@ class FlashForgePlugin(octoprint.plugin.SettingsPlugin,
 			self._serial_obj.makeexclusive(False)
 			self._serial_obj.enable_keep_alive(True)
 			# NB M23 select will also trigger a print on FlashForge
-			if self._printer_profile['name'] in SPECIAL_SD_HANDLING:
+			if self._printer_profile['name'] in self.SPECIAL_SD_HANDLING:
 				self._comm.selectFile("1:%s\r\n" % remote_name, True)
 			else:	
 				self._comm.selectFile("0:/user/%s\r\n" % remote_name, True)


### PR DESCRIPTION
The Upload is working also the start to print from SD Card.
The printer is not answering to the SD listening request (not supported by the firmware used).
does it make sense to fake the M27 support based on a filedatabase what is uploaded to the printer using octoprint but i don't know if it is possible to inject that command in a way that the printer serial response is modified by the plugin.